### PR TITLE
feat: Create Event, Category, and EventAttendees models and migrations

### DIFF
--- a/backend/src/migrations/20240824211713-create-event-attendees.cjs
+++ b/backend/src/migrations/20240824211713-create-event-attendees.cjs
@@ -1,0 +1,130 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Create the Categories table
+    await queryInterface.createTable("Categories", {
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+        allowNull: false,
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("now"),
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("now"),
+      },
+    });
+
+    // Create the Events table
+    await queryInterface.createTable("Events", {
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+        allowNull: false,
+      },
+      title: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      description: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      date: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      location: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      capacity: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      categoryId: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: "Categories",
+          key: "id",
+        },
+        allowNull: false,
+        onUpdate: "CASCADE",
+        onDelete: "SET NULL",
+      },
+      organizerId: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: "Users", // Assuming the Users table already exists
+          key: "id",
+        },
+        allowNull: false,
+        onUpdate: "CASCADE",
+        onDelete: "SET NULL",
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("now"),
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("now"),
+      },
+    });
+
+    // Create the EventAttendees join table
+    await queryInterface.createTable("EventAttendees", {
+      eventId: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: "Events",
+          key: "id",
+        },
+        allowNull: false,
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: "Users", // Assuming the Users table already exists
+          key: "id",
+        },
+        allowNull: false,
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("now"),
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("now"),
+      },
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Drop tables in reverse order to avoid foreign key constraint issues
+    await queryInterface.dropTable("EventAttendees");
+    await queryInterface.dropTable("Events");
+    await queryInterface.dropTable("Categories");
+  },
+};

--- a/backend/src/models/EventAttendees.js
+++ b/backend/src/models/EventAttendees.js
@@ -1,0 +1,27 @@
+import { DataTypes } from "sequelize";
+import sequelize from "../config/database.js";
+
+const EventAttendees = sequelize.define(
+  "EventAttendees",
+  {
+    eventId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: "Events",
+        key: "id",
+      },
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: "Users",
+        key: "id",
+      },
+    },
+  },
+  {
+    timestamps: false, // If you don't need createdAt/updatedAt timestamps
+  }
+);
+
+export default EventAttendees;

--- a/backend/src/models/categories.js
+++ b/backend/src/models/categories.js
@@ -1,0 +1,26 @@
+import { DataTypes } from "sequelize";
+import sequelize from "../config/database.js";
+
+const categories = sequelize.define(
+  "categories",
+  {
+	id: {
+	  type: DataTypes.INTEGER,
+	  autoIncrement: true,
+	  primaryKey: true,
+	},
+	name: {
+	  type: DataTypes.STRING,
+	  allowNull: false,
+	},
+	description: {
+	  type: DataTypes.TEXT,
+	  allowNull: true,
+	},
+  },
+  {
+	timestamps: true,
+  }
+);
+
+export default categories;

--- a/backend/src/models/event.js
+++ b/backend/src/models/event.js
@@ -1,0 +1,60 @@
+import { DataTypes } from "sequelize";
+import sequelize from "../config/database.js";
+import User from "./user.js";
+import categories from "./categories.js";
+import EventAttendees from "./EventAttendees.js";
+
+const Event = sequelize.define(
+    "Event",
+    {
+        id: {
+            type: DataTypes.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        title: {
+            type: DataTypes.STRING,
+            allowNull: false,
+        },
+        description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+        },
+        date: {
+            type: DataTypes.DATE,
+            allowNull: false,
+        },
+        location: {
+            type: DataTypes.STRING,
+            allowNull: false,
+        },
+        organizerId: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+        },
+        attendeesIds: {
+            type: DataTypes.ARRAY(DataTypes.INTEGER),
+            allowNull: true,
+        },
+        capacity: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+        },
+        categoryId: {
+            type: DataTypes.INTEGER,
+            references: {
+                model: categories,
+                key: 'id',
+            },
+            allowNull: false,
+        },
+    },
+    {
+        timestamps: true,
+    }
+);
+
+Event.belongsTo(User, { as: 'organizer', foreignKey: 'organizerId' });
+Event.belongsToMany(User, { as: 'attendees', through: EventAttendees, foreignKey: 'eventId' });
+
+export default Event;

--- a/backend/src/models/user.js
+++ b/backend/src/models/user.js
@@ -1,10 +1,12 @@
-import { DataTypes } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 import sequelize from "../config/database.js";
+import Event from "./event.js";
+import EventAttendees from "./EventAttendees.js";
 
-const User = sequelize.define(
-  "User",
+class User extends Model {}
+
+User.init(
   {
-    // Define attributes
     id: {
       type: DataTypes.INTEGER,
       autoIncrement: true,
@@ -43,8 +45,18 @@ const User = sequelize.define(
     },
   },
   {
+    sequelize,
+    modelName: "User",
     timestamps: true,
   }
 );
+
+// Associations
+User.hasMany(Event, { as: "organizedEvents", foreignKey: "organizerId" });
+User.belongsToMany(Event, {
+  through: EventAttendees,
+  as: "attendedEvents",
+  foreignKey: "userId",
+});
 
 export default User;


### PR DESCRIPTION
- Added migration files for creating the `Events`, `Categories`, and `EventAttendees` tables.
- Set up relationships between Events, Users (organizers and attendees), and Categories.
- Ensured cascading updates and deletes to maintain referential integrity.
close #14 